### PR TITLE
Allow multiple ingresses deployed to one namespace

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -9,7 +9,6 @@ app_image:
   pullPolicy: Always
 
 ingress:
-  secretName: ai-qa-cert
   path: /
   certManagerAnnotationPrefix: cert-manager.io
 

--- a/kolga/libs/kubernetes.py
+++ b/kolga/libs/kubernetes.py
@@ -484,7 +484,10 @@ class Kubernetes:
                 "env": settings.ENVIRONMENT_SLUG,
             },
             "image": project.image,
-            "ingress": {"maxBodySize": settings.K8S_INGRESS_MAX_BODY_SIZE},
+            "ingress": {
+                "maxBodySize": settings.K8S_INGRESS_MAX_BODY_SIZE,
+                "secretName": project.ingress_secret_name
+            },
             "namespace": namespace,
             "releaseOverride": f"{settings.ENVIRONMENT_SLUG}-{kuberenetes_safe_name(project.name)}",
             "replicaCount": project.replica_count,

--- a/kolga/libs/project.py
+++ b/kolga/libs/project.py
@@ -22,6 +22,7 @@ PROJECT_ARG_SETTINGS_MAPPING = {
     "ENVIRONMENT_URL": "url",
     "K8S_ADDITIONAL_HOSTNAMES": "additional_urls",
     "K8S_INGRESS_BASIC_AUTH": "basic_auth_data",
+    "K8S_INGRESS_SECRET_NAME": "ingress_secret_name",
     "K8S_LIVENESS_PATH": "liveness_path",
     "K8S_PROBE_FAILURE_THRESHOLD": "probe_failure_threshold",
     "K8S_PROBE_INITIAL_DELAY": "probe_initial_delay",
@@ -65,6 +66,7 @@ class Project:
         urls: str = "",
         is_dependent_project: bool = False,
         deploy_name: str = "",
+        ingress_secret_name: str = "",
         **kwargs: str,
     ) -> None:
         # Set variables from arguments and if they do not exist,
@@ -83,6 +85,7 @@ class Project:
         self.basic_auth_secret_name = basic_auth_secret_name
         self.urls = urls
         self.is_dependent_project = is_dependent_project
+        self.ingress_secret_name = ingress_secret_name
 
         if not image:
             docker = Docker()
@@ -104,6 +107,9 @@ class Project:
         self.deploy_name = deploy_name
         if not deploy_name:
             self.deploy_name = get_deploy_name(track=track, postfix=postfix)
+
+        if not self.ingress_secret_name:
+            self.ingress_secret_name = f"{self.deploy_name}-ingress-tls"
 
         self.dependency_projects = (
             [] if is_dependent_project else self.get_dependency_projects(self.track)

--- a/kolga/settings.py
+++ b/kolga/settings.py
@@ -102,6 +102,7 @@ _VARIABLE_DEFINITIONS: Dict[str, List[Any]] = {
     "K8S_CERTMANAGER_USE_OLD_API": [env.bool, False],
     "K8S_INGRESS_MAX_BODY_SIZE": [env.str, "100m"],
     "K8S_INGRESS_PREVENT_ROBOTS": [env.bool, False],
+    "K8S_INGRESS_SECRET_NAME": [env.str, ""],
     "K8S_INGRESS_WHITELIST_IPS": [env.str, ""],
     "K8S_LIVENESS_PATH": [env.str, "/healthz"],
     "K8S_NAMESPACE": [env.str, ""],
@@ -190,6 +191,7 @@ class Settings:
     K8S_CERTMANAGER_USE_OLD_API: bool
     K8S_INGRESS_MAX_BODY_SIZE: str
     K8S_INGRESS_PREVENT_ROBOTS: bool
+    K8S_INGRESS_SECRET_NAME: str
     K8S_INGRESS_WHITELIST_IPS: str
     K8S_LIVENESS_PATH: str
     K8S_NAMESPACE: str


### PR DESCRIPTION
Certificate secret to contain application name to prevent collisions when multiple apps deployed to same namespace