### PR TITLE
Revert "Ingress version logic"

### DIFF
--- a/helm/templates/05-ingress.yaml
+++ b/helm/templates/05-ingress.yaml
@@ -1,8 +1,11 @@
 {{- if and (not .Values.ingress.disabled) (not .Values.jobsOnly) -}}
-{{- if (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") }}
+{{- $stableApi := .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress"}}
+{{- if $stableApi -}}
 apiVersion: networking.k8s.io/v1
-{{- else }}
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
 apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
@@ -52,11 +55,11 @@ spec:
       http:
         paths:
           - path: {{ $.Values.ingress.path }}
-            {{- if ($.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") }}
+            {{- if $stableApi }}
             pathType: Prefix
             {{- end }}
             backend:
-              {{- if ($.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") }}
+              {{- if $stableApi }}
               service:
                 name: {{ template "appname" $ }}-service
                 port:


### PR DESCRIPTION
This reverts commit 1bc3c8ade9289e751ce0f7ea9e34bb2d8a0cc1a2.

Apparently logic was working originally, and issue tried to fix related to old helm deployment comparison.

# Does this PR meet the acceptance criteria

* **Changelog**
    * [ ] Changelog entry included
    * [ ] Changelog entry not needed
* **Documentation**
    * [ ] Documentation included
    * [ ] Documentation not needed
* **Tests**
    * [ ] Tests included
    * [ ] Tests not needed
